### PR TITLE
Use correct pen up position

### DIFF
--- a/xy/device.py
+++ b/xy/device.py
@@ -59,7 +59,7 @@ class Device(object):
         time.sleep(0.15)
         for point in points:
             self.move(*point)
-        self.pen(up)
+        self.pen(self.up if up is None else up)
         time.sleep(0.15)
 
     def gcode(self, g):


### PR DESCRIPTION
self.pen(None) will move the pen motor to a default position, which may seem like "up" but actually isn't. In my case, it was causing the pen to hit the axis beam, throwing off the pen tip precision.
